### PR TITLE
Update Referentiedata.csv

### DIFF
--- a/Referentiedata.csv
+++ b/Referentiedata.csv
@@ -415,7 +415,7 @@ DEFECTSTATUS;MEL;Gemeld;;;;;Onderhoud;;
 DOELGROEP;EEN;Persoon;Woonruimte is bestemd voor en/of huurder vormt een eenpersoonshuishouden;;;;Vastgoed, Woonruimteverdeling;;
 DOELGROEP;GEK;Gezin met kinderen;Woonruimte is bestemd voor en/of huurder maakt onderdeel uit van een huishouden bestaande uit meerdere natuurlijke personen en kinderen die tezamen een gezin vormen OBSOLETE;21-04-2023;23-06-2023;;Vastgoed, Woonruimteverdeling;;
 DOELGROEP;GEZ;Gezin;leefverband van één of meer volwassenen die verantwoordelijkheid dragen voor de verzorging en opvoeding van één of meer kinderen;;;;Vastgoed, Woonruimteverdeling;;
-DOELGROEP;HZO;Huishouden zonder kinderen;Huishouden zonder kinderen - meerdere volwassen personen (tot een bepaald maximum leeftijd) die samen een huishouden vormen en (nog) geen kinderen verzorgen.;23-06-2023;;;Vastgoed, Woonruimteverdeling;;
+DOELGROEP;HZO;Huishouden zonder kinderen;Huishouden zonder kinderen - Eén of meerdere volwassen personen (tot een bepaald maximum leeftijd) die samen een huishouden vormen en (nog) geen kinderen verzorgen.;23-06-2023;;;Vastgoed, Woonruimteverdeling;;
 DOELGROEP;JON;Jongeren;Woonruimte is bestemd voor en/of huurder heeft op het moment van toewijzing een specifieke maximum leeftijd;;;;Vastgoed, Woonruimteverdeling;;
 DOELGROEP;MEE;Meergezins;Woonruimte is bestemd voor en/of huurder maakt onderdeel uit van een groep bestaande uit meerdere huishoudens;;;;Vastgoed, Woonruimteverdeling;;
 DOELGROEP;SEN;Senioren;Woonruimte is bestemd voor en/of huurder heeft op het moment van toewijzing een specifieke minimum leeftijd;;;;Vastgoed, Woonruimteverdeling;;


### PR DESCRIPTION
Vanuit verzoek:

**"Ik heb even de link geopend, maar ik zie niet de aangepaste omschrijving achter de doelgroepcode HZO.

Zie ook onze mailwisseling van 30 juni in de bijlage van deze mail.

Ik vond de omschrijving van te beperkend en heb voorgesteld deze wat ruimer te nemen, zoals: ‘Eén of twee volwassen personen die een huishouden vormen en geen kinderen verzorgen’.

Zou je er nogmaals naar willen kijken? Bedankt alvast!"**

 