### PR TITLE
Toevoeging nieuwe VERA prijscomponentdetailsoorten

### DIFF
--- a/Referentiedata.csv
+++ b/Referentiedata.csv
@@ -1687,9 +1687,9 @@ PRIJSCOMPONENTDETAILSOORT;AKO;Administratiekosten;Administratiekosten zijn de ko
 PRIJSCOMPONENTDETAILSOORT;ALA;Alarm bewaking;Periodieke kosten voor het alarm en de bewaking van de woning;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;BED;Servicekosten bedrijfsruimten;Periodieke kosten voor services m.b.t. bedrijfsruimten;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;BEH;Beheerder(s);Periodieke kosten voor de beheerder(s) van de eenheid en/of het complex;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
-PRIJSCOMPONENTDETAILSOORT;BER;Berging;Periodieke kosten voor het gebruik van een afzonderlijke berging.;;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;BER;Berging;Periodieke kosten voor het gebruik van een afzonderlijke berging.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;BOR;Borg;Een door de huurder betaalde waarborgsom die dient als zekerheid voor de verhuurder.;;;PRIJSCOMPONENTSOORT.EEN;Overeenkomsten
-PRIJSCOMPONENTDETAILSOORT;CAM;Cameratoezicht;Periodieke kosten voor camerabeveiliging of cameraregistratie in of rondom het complex.;;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;CAM;Cameratoezicht;Periodieke kosten voor camerabeveiliging of cameraregistratie in of rondom het complex.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;DIE;Dienst- en recreatieruimten;De periodieke kosten voor reparaties en groot onderhoud aan dienstruimten en recreatieruimten. Deze kosten komen meestal voor bij senioren- of bejaardenwoningen. Het gaat niet om de inventaris, het schoonmaken van de ruimten of onderhoud aan de tuin.;;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;ELE;Electriciteit;Elektriciteit is een vorm van energie die voortkomt uit de beweging of het stromen van elektrische ladingen, meestal door een geleider zoals koper of aluminium. Het is een fundamenteel natuurkundig verschijnsel dat wordt gebruikt als energiebron voor talloze toepassingen in ons dagelijks leven en de industrie.;;;PRIJSCOMPONENTSOORT.VER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;ELI;Elektrische installaties;Periodieke kosten voor het gebruik van elektrische installaties;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten

--- a/Referentiedata.csv
+++ b/Referentiedata.csv
@@ -1682,11 +1682,14 @@ PRESTATIEAFSPRAAK;HUU;Huurverhoging t.b.v. investering;Inkomensafhankelijke huur
 PRIJSAANPASSINGSOORT;KOR;Korting;;;;;Financiën
 PRIJSAANPASSINGSOORT;TOE;Toeslag;;;;;Financiën
 PRIJSCOMPONENTDETAILSOORT;AFV;Afvalstoffenheffing;Periodieke kosten voor de gemeentelijke belasting inzake inzameling en verwerking van huishoudelijk afval.;3-10-2025;;PRIJSCOMPONENTSOORT.NET;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;AIR;Airconditioning;Periodieke kosten voor het gebruik of onderhoud van airconditioninginstallaties in de eenheid of gemeenschappelijke ruimten.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;AKO;Administratiekosten;Administratiekosten zijn de kosten die een organisatie of bedrijf maakt voor het uitvoeren van administratieve taken. Dit omvat alle werkzaamheden die nodig zijn om de dagelijkse bedrijfsvoering te ondersteunen en te organiseren. Denk hierbij aan het verwerken, beheren en bijhouden van financiële en operationele gegevens.;;;PRIJSCOMPONENTSOORT.EEN;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;ALA;Alarm bewaking;Periodieke kosten voor het alarm en de bewaking van de woning;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;BED;Servicekosten bedrijfsruimten;Periodieke kosten voor services m.b.t. bedrijfsruimten;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;BEH;Beheerder(s);Periodieke kosten voor de beheerder(s) van de eenheid en/of het complex;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;BER;Berging;Periodieke kosten voor het gebruik van een afzonderlijke berging.;;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;BOR;Borg;Een door de huurder betaalde waarborgsom die dient als zekerheid voor de verhuurder.;;;PRIJSCOMPONENTSOORT.EEN;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;CAM;Cameratoezicht;Periodieke kosten voor camerabeveiliging of cameraregistratie in of rondom het complex.;;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;DIE;Dienst- en recreatieruimten;De periodieke kosten voor reparaties en groot onderhoud aan dienstruimten en recreatieruimten. Deze kosten komen meestal voor bij senioren- of bejaardenwoningen. Het gaat niet om de inventaris, het schoonmaken van de ruimten of onderhoud aan de tuin.;;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;ELE;Electriciteit;Elektriciteit is een vorm van energie die voortkomt uit de beweging of het stromen van elektrische ladingen, meestal door een geleider zoals koper of aluminium. Het is een fundamenteel natuurkundig verschijnsel dat wordt gebruikt als energiebron voor talloze toepassingen in ons dagelijks leven en de industrie.;;;PRIJSCOMPONENTSOORT.VER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;ELI;Elektrische installaties;Periodieke kosten voor het gebruik van elektrische installaties;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
@@ -1695,6 +1698,7 @@ PRIJSCOMPONENTDETAILSOORT;ENE;Energie voor gemeenschappelijke ruimten;Dit zijn b
 PRIJSCOMPONENTDETAILSOORT;EPV;Energieprestatievergoeding;Een vergoeding die verhuurder aan huurder mag vragen voor een huurwoning die zelf energie opwekt;;;PRIJSCOMPONENTSOORT.VER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;GAS;Gas;Aardgas is een fossiele brandstof die voornamelijk bestaat uit methaan.;;;PRIJSCOMPONENTSOORT.VER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;GEM;Reparatie gem. ruimten;Periodieke kosten voor het repareren van defecten aan gemeenschappelijke ruimten;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;GGR;Gas voor gemeenschappelijke ruimten;Dit zijn bijvoorbeeld de periodieke kosten voor gas voor bijvoorbeeld: centrale verwarming van gangen, hal, recreatieruimte of andere gemeenschappelijke voorzieningen. Alleen voor gemeenschappelijke ruimten.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;GHB;Gladheidsbestrijding;Periodieke kosten voor het bestrijden van gladheid rondom de eenheid;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;GLB;Glasbewassing;Periodieke kosten voor het wassen van glas van ramen en deuren van de eenheid;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;GLF;Glasfonds;Periodieke kosten voor de voorziening voor repareren van glasschade;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
@@ -1717,6 +1721,7 @@ PRIJSCOMPONENTDETAILSOORT;ONH;Overige netto huur component;Een overige netto huu
 PRIJSCOMPONENTDETAILSOORT;OVE;Overige kosten gem. ruimten;Periodieke kosten voor overige kosten voor gemeenschappelijke ruimten (naast schoonmaak, energie en reparatie);4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;PBU;Parkeerplaats buiten;Uitpandige parkeerplek;;;PRIJSCOMPONENTSOORT.PAR;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;PGA;Parkeergarage;Inpandige parkeerplek collectief;;;PRIJSCOMPONENTSOORT.PAR;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;PRM;Promotiekosten (BOG);Periodieke bijdrage in promotie- of marketingkosten voor bedrijfsonroerend goed.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;RIH;Rioolheffing;Periodieke kosten voor de gemeentelijke belasting inzake afvoer en verwerking van afvalwater en hemelwater, en het onderhoud van de riolering.;3-10-2025;;PRIJSCOMPONENTSOORT.NET;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;RIO;Rioolfonds;Periodieke kosten voor deelname aan een voorziening of fonds dat de kosten voor rioolontstoppingen en kleine rioolreparaties dekt.;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;SCE;Schoonmaak eenheid;Periodieke kosten voor schoonmaak van de eenheid;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
@@ -1724,6 +1729,8 @@ PRIJSCOMPONENTDETAILSOORT;SCH;Schoonmaak van gemeenschappelijke ruimten;De perio
 PRIJSCOMPONENTDETAILSOORT;SIG;Signaallevering (o.a. CAI);Periodieke kosten voor signaallevering (o.a. CAI);4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;STV;Schoorsteenvegen;Periodieke kosten voor het vegen van de schoorsteen;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;SUB;Subsidiabele servicekosten;VERVALLEN - Gebruik Prijscomponentsubsidiesoort.;;1-1-2022;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;SUC;Subsidiecomponent algemeen;Component voor het administreren van structurele subsidies die niet onder huurtoeslag of servicekosten vallen.;;;PRIJSCOMPONENTSOORT.HUA;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;TBE;Technisch beheer;Periodieke kosten voor technisch beheer van eenheid of complex, anders dan reguliere beheerder(s) kosten.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;VER;Verenigingskosten;Periodieke kosten voor lidmaatschap van  verenigingen;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;VOL;Volkstuin;Periodieke kosten voor het gebruik van een volkstuin;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;VVE;VVE kosten;Periodieke kosten voor VVE-lidmaatschap;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten

--- a/Referentiedata.csv
+++ b/Referentiedata.csv
@@ -1729,7 +1729,7 @@ PRIJSCOMPONENTDETAILSOORT;SCH;Schoonmaak van gemeenschappelijke ruimten;De perio
 PRIJSCOMPONENTDETAILSOORT;SIG;Signaallevering (o.a. CAI);Periodieke kosten voor signaallevering (o.a. CAI);4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;STV;Schoorsteenvegen;Periodieke kosten voor het vegen van de schoorsteen;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;SUB;Subsidiabele servicekosten;VERVALLEN - Gebruik Prijscomponentsubsidiesoort.;;1-1-2022;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
-PRIJSCOMPONENTDETAILSOORT;SUC;Subsidiecomponent algemeen;Component voor het administreren van structurele subsidies die niet onder huurtoeslag of servicekosten vallen.;;;PRIJSCOMPONENTSOORT.HUA;Overeenkomsten
+PRIJSCOMPONENTDETAILSOORT;SUC;Subsidie algemeen;Component voor het administreren van structurele subsidies die niet onder huurtoeslag of servicekosten vallen.;13-2-2026;;PRIJSCOMPONENTSOORT.HUA;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;TBE;Technisch beheer;Periodieke kosten voor technisch beheer van eenheid of complex, anders dan reguliere beheerder(s) kosten.;13-2-2026;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;VER;Verenigingskosten;Periodieke kosten voor lidmaatschap van  verenigingen;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten
 PRIJSCOMPONENTDETAILSOORT;VOL;Volkstuin;Periodieke kosten voor het gebruik van een volkstuin;4-11-2022;;PRIJSCOMPONENTSOORT.SER;Overeenkomsten


### PR DESCRIPTION
Aanvullende prijscomponentdetailsoorten toegevoegd die structureel voorkomen maar nog niet in VERA aanwezig waren.

Toegevoegd: AIR, BER, CAM, GGR, PRM, SUC, TBE


**AIR – Airconditioning**

Waarom toegevoegd:
Airconditioning komt als aparte periodieke kostenpost voor bij meerdere klanten. Deze kan niet logisch worden ondergebracht onder:

MVE (Mechanische ventilatie)
WAI (Warmte-installaties)

**BER – Berging**

Waarom toegevoegd:
Berging was niet aanwezig. Dit valt niet onder parkeercomponenten (IGA/PBU/PGA).

**CAM – Cameratoezicht**

Waarom toegevoegd:
Hoewel ALA (Alarm bewaking) bestaat, wordt cameraregistratie en cameratoezicht in de praktijk als aparte voorziening doorbelast.

**GGR – Gas verbruik gemeenschappelijke ruimten**

Waarom toegevoegd:
Voor elektriciteit in gemeenschappelijke ruimten bestaat ENE.
Voor gas in gemeenschappelijke ruimten ontbrak een expliciete tegenhanger.

**PRM – Promotiekosten**

Waarom toegevoegd:
Bij commercieel vastgoed (BOG) komen promotie- en marketingbijdragen structureel voor.
Deze passen niet onder AKO (Administratiekosten) en ook niet onder reguliere servicekosten.

**SUC – Subsidie algemeen**

Waarom toegevoegd:
MAT is historisch en specifiek voor huurtoeslag (oude regeling).
Er bestaan andere structurele subsidiecomponenten die niet onder MAT of reguliere huurcomponenten vallen.

**TBE – Technisch beheer**

Waarom toegevoegd:
BEH (Beheerder(s)) ziet primair op personen/dienstverlening.
Technisch beheer wordt als aparte kostensoort onderscheiden van sociaal/operationeel beheer.